### PR TITLE
Added parameters to configure Fody.ToString output

### DIFF
--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -35,7 +35,7 @@ public class ModuleWeaver
 
     public void Execute()
     {
-        stringBuilderType = ModuleDefinition.ImportReference(typeof (StringBuilder));
+        stringBuilderType = ModuleDefinition.ImportReference(typeof(StringBuilder));
         appendString = ModuleDefinition.ImportReference(typeof(StringBuilder).GetMethod("Append", new[] { typeof(object) }));
         moveNext = ModuleDefinition.ImportReference(typeof(IEnumerator).GetMethod("MoveNext"));
         current = ModuleDefinition.ImportReference(typeof(IEnumerator).GetProperty("Current").GetGetMethod());
@@ -75,7 +75,7 @@ public class ModuleWeaver
         {
             method.Body.Variables.Add(new VariableDefinition(stringBuilderType));
 
-            var enumeratorType = ModuleDefinition.ImportReference(typeof (IEnumerator));
+            var enumeratorType = ModuleDefinition.ImportReference(typeof(IEnumerator));
             method.Body.Variables.Add(new VariableDefinition(enumeratorType));
 
             method.Body.Variables.Add(new VariableDefinition(ModuleDefinition.TypeSystem.Boolean));
@@ -183,17 +183,17 @@ public class ModuleWeaver
         ins.Add(Instruction.Create(OpCodes.Ldc_I4, index));
 
         var get = ModuleDefinition.ImportReference(property.GetGetMethod(targetType));
-            
+
         ins.Add(Instruction.Create(OpCodes.Ldarg_0));
         ins.Add(Instruction.Create(OpCodes.Call, get));
 
-        if ( get.ReturnType.IsValueType)
+        if (get.ReturnType.IsValueType)
         {
             var returnType = ModuleDefinition.ImportReference(property.GetMethod.ReturnType);
-            if( returnType.FullName == "System.DateTime" )
+            if (returnType.FullName == "System.DateTime")
             {
-                var convertToUtc = ModuleDefinition.ImportReference(returnType.Resolve().FindMethod( "ToUniversalTime" ));
-                
+                var convertToUtc = ModuleDefinition.ImportReference(returnType.Resolve().FindMethod("ToUniversalTime"));
+
                 var variable = new VariableDefinition(returnType);
                 variables.Add(variable);
                 ins.Add(Instruction.Create(OpCodes.Stloc, variable));
@@ -211,7 +211,7 @@ public class ModuleWeaver
             {
                 AssignFalseToFirstFLag(ins);
 
-                If(ins, 
+                If(ins,
                     nc => nc.Add(Instruction.Create(OpCodes.Dup)),
                     nt =>
                     {
@@ -253,23 +253,23 @@ public class ModuleWeaver
                                             format = "{0}";
                                         }
 
-                                        t.Add(Instruction.Create(OpCodes.Ldstr, format));  
+                                        t.Add(Instruction.Create(OpCodes.Ldstr, format));
 
                                         t.Add(Instruction.Create(OpCodes.Ldc_I4, 1));
-                                        t.Add(Instruction.Create(OpCodes.Newarr, ModuleDefinition.TypeSystem.Object)); 
-                                        t.Add(Instruction.Create(OpCodes.Stloc, body.Variables[4])); 
-                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4])); 
+                                        t.Add(Instruction.Create(OpCodes.Newarr, ModuleDefinition.TypeSystem.Object));
+                                        t.Add(Instruction.Create(OpCodes.Stloc, body.Variables[4]));
+                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4]));
 
-                                        t.Add(Instruction.Create(OpCodes.Ldc_I4_0)); 
+                                        t.Add(Instruction.Create(OpCodes.Ldc_I4_0));
 
-                                        t.Add(Instruction.Create(OpCodes.Ldloc_2)); 
-                                        t.Add(Instruction.Create(OpCodes.Callvirt, current)); 
+                                        t.Add(Instruction.Create(OpCodes.Ldloc_2));
+                                        t.Add(Instruction.Create(OpCodes.Callvirt, current));
 
 
                                         t.Add(Instruction.Create(OpCodes.Stelem_Ref));
-                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4])); 
+                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4]));
 
-                                        t.Add(Instruction.Create(OpCodes.Call, formatMethod)); 
+                                        t.Add(Instruction.Create(OpCodes.Call, formatMethod));
                                     },
                                     e => e.Add(Instruction.Create(OpCodes.Ldstr, "null")));
                                 ins.Add(Instruction.Create(OpCodes.Callvirt, appendString));
@@ -277,17 +277,17 @@ public class ModuleWeaver
                             });
 
                         AppendString(ins, "]");
-                        StringBuilderToString(ins);       
+                        StringBuilderToString(ins);
                     },
                     nf =>
                     {
                         ins.Add(Instruction.Create(OpCodes.Pop));
-                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null")); 
-                    });              
+                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null"));
+                    });
             }
             else
             {
-                If(ins, 
+                If(ins,
                     c =>
                     {
                         ins.Add(Instruction.Create(OpCodes.Dup));
@@ -297,7 +297,7 @@ public class ModuleWeaver
                     e =>
                     {
                         ins.Add(Instruction.Create(OpCodes.Pop));
-                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null"));   
+                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null"));
                     });
             }
         }
@@ -316,7 +316,7 @@ public class ModuleWeaver
 
     void NewStringBuilder(Collection<Instruction> ins)
     {
-        var stringBuilderConstructor = ModuleDefinition.ImportReference(typeof (StringBuilder).GetConstructor(new Type[] {}));
+        var stringBuilderConstructor = ModuleDefinition.ImportReference(typeof(StringBuilder).GetConstructor(new Type[] { }));
         ins.Add(Instruction.Create(OpCodes.Newobj, stringBuilderConstructor));
         ins.Add(Instruction.Create(OpCodes.Stloc_1));
     }
@@ -336,7 +336,7 @@ public class ModuleWeaver
     void While(
         Collection<Instruction> ins,
         Action<Collection<Instruction>> condition,
-        Action<Collection<Instruction>> body )
+        Action<Collection<Instruction>> body)
     {
         var loopBegin = Instruction.Create(OpCodes.Nop);
         var loopEnd = Instruction.Create(OpCodes.Nop);
@@ -394,7 +394,7 @@ public class ModuleWeaver
     {
         If(ins,
            c => c.Add(Instruction.Create(OpCodes.Ldloc_3)),
-           t => AppendString(t, ", "),
+           t => AppendString(t, PropertiesSeparator),
            e =>
                {
                    ins.Add(Instruction.Create(OpCodes.Ldc_I4_1));
@@ -405,38 +405,47 @@ public class ModuleWeaver
     string GetFormatString(TypeDefinition type, PropertyDefinition[] properties)
     {
         var sb = new StringBuilder();
-        sb.Append("{{T: \"");
         var offset = 0;
-        if (!type.HasGenericParameters)
-        {
-            sb.Append(type.Name);
-        }
-        else
-        {
-            var name = type.Name.Remove(type.Name.IndexOf('`'));
-            offset = type.GenericParameters.Count;
-            sb.Append(name);
-            sb.Append('<');
-            for (var i = 0; i < offset; i++)
-            {
-                sb.Append("{");
-                sb.Append(i);
-                sb.Append("}");
-                if (i + 1 != offset)
-                {
-                    sb.Append(", ");
-                }
-            }
-            sb.Append('>');
-        }
-        sb.Append("\", ");
 
+        if (WrapWithBrackets)
+        {
+            sb.Append("{{");
+        }
+
+        if (WriteTypeName)
+        {
+            sb.AppendFormat("T{0}\"", PropertyNameToValueSeparator);
+
+            if (!type.HasGenericParameters)
+            {
+                sb.Append(type.Name);
+            }
+            else
+            {
+                var name = type.Name.Remove(type.Name.IndexOf('`'));
+                offset = type.GenericParameters.Count;
+                sb.Append(name);
+                sb.Append('<');
+                for (var i = 0; i < offset; i++)
+                {
+                    sb.Append("{");
+                    sb.Append(i);
+                    sb.Append("}");
+                    if (i + 1 != offset)
+                    {
+                        sb.Append(PropertiesSeparator);
+                    }
+                }
+                sb.Append('>');
+            }
+            sb.Append("\"" + PropertiesSeparator);
+        }
 
         for (var i = 0; i < properties.Length; i++)
         {
             var property = properties[i];
             sb.Append(property.Name);
-            sb.Append(": ");
+            sb.Append(PropertyNameToValueSeparator);
 
             if (HaveToAddQuotes(property.PropertyType))
             {
@@ -450,9 +459,9 @@ public class ModuleWeaver
             {
                 sb.Append(":O");
             }
-            if( property.PropertyType.FullName == "System.TimeSpan" )
+            if (property.PropertyType.FullName == "System.TimeSpan")
             {
-                sb.Append( ":c" );
+                sb.Append(":c");
             }
 
             sb.Append("}");
@@ -464,10 +473,15 @@ public class ModuleWeaver
 
             if (i != properties.Length - 1)
             {
-                sb.Append(", ");
+                sb.Append(PropertiesSeparator);
             }
         }
-        sb.Append("}}");
+
+        if (WrapWithBrackets)
+        {
+            sb.Append("}}");
+        }
+
         var format = sb.ToString();
         return format;
     }
@@ -475,14 +489,14 @@ public class ModuleWeaver
     static bool HaveToAddQuotes(TypeReference type)
     {
         var name = type.FullName;
-        if(name == "System.String" || name == "System.Char" || name == "System.DateTime" || name == "System.TimeSpan"
+        if (name == "System.String" || name == "System.Char" || name == "System.DateTime" || name == "System.TimeSpan"
             || name == "System.Guid")
         {
             return true;
         }
 
         var resolved = type.Resolve();
-        return  resolved != null && resolved.IsEnum;
+        return resolved != null && resolved.IsEnum;
     }
 
     void RemoveReference()
@@ -506,5 +520,28 @@ public class ModuleWeaver
     PropertyDefinition[] RemoveIgnoredProperties(PropertyDefinition[] allProperties)
     {
         return allProperties.Where(x => x.CustomAttributes.All(y => y.AttributeType.Name != "IgnoreDuringToStringAttribute")).ToArray();
+    }
+
+    private string PropertyNameToValueSeparator => ReadStringValueFromConfig("PropertyNameToValueSeparator", ": ");
+
+    private string PropertiesSeparator => ReadStringValueFromConfig("PropertiesSeparator", ", ");
+
+    private bool WrapWithBrackets => ReadBoolValueFromConfig("WrapWithBrackets", true);
+
+    private bool WriteTypeName => ReadBoolValueFromConfig("WriteTypeName", true);
+
+    private string ReadStringValueFromConfig(string nodeName, string defaultValue)
+    {
+        var node = Config?.Attributes().FirstOrDefault(a => a.Name.LocalName == nodeName);
+        return node?.Value ?? defaultValue;
+    }
+
+    private bool ReadBoolValueFromConfig(string nodeName, bool defaultValue)
+    {
+        var node = Config?.Attributes().FirstOrDefault(a => a.Name.LocalName == nodeName);
+        bool nodeValue;
+        return node != null && bool.TryParse(node.Value, out nodeValue) 
+            ? nodeValue 
+            : defaultValue;
     }
 }

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -35,7 +35,7 @@ public class ModuleWeaver
 
     public void Execute()
     {
-        stringBuilderType = ModuleDefinition.ImportReference(typeof(StringBuilder));
+        stringBuilderType = ModuleDefinition.ImportReference(typeof (StringBuilder));
         appendString = ModuleDefinition.ImportReference(typeof(StringBuilder).GetMethod("Append", new[] { typeof(object) }));
         moveNext = ModuleDefinition.ImportReference(typeof(IEnumerator).GetMethod("MoveNext"));
         current = ModuleDefinition.ImportReference(typeof(IEnumerator).GetProperty("Current").GetGetMethod());
@@ -75,7 +75,7 @@ public class ModuleWeaver
         {
             method.Body.Variables.Add(new VariableDefinition(stringBuilderType));
 
-            var enumeratorType = ModuleDefinition.ImportReference(typeof(IEnumerator));
+            var enumeratorType = ModuleDefinition.ImportReference(typeof (IEnumerator));
             method.Body.Variables.Add(new VariableDefinition(enumeratorType));
 
             method.Body.Variables.Add(new VariableDefinition(ModuleDefinition.TypeSystem.Boolean));
@@ -183,17 +183,17 @@ public class ModuleWeaver
         ins.Add(Instruction.Create(OpCodes.Ldc_I4, index));
 
         var get = ModuleDefinition.ImportReference(property.GetGetMethod(targetType));
-
+            
         ins.Add(Instruction.Create(OpCodes.Ldarg_0));
         ins.Add(Instruction.Create(OpCodes.Call, get));
 
         if (get.ReturnType.IsValueType)
         {
             var returnType = ModuleDefinition.ImportReference(property.GetMethod.ReturnType);
-            if (returnType.FullName == "System.DateTime")
+            if ( returnType.FullName == "System.DateTime" )
             {
                 var convertToUtc = ModuleDefinition.ImportReference(returnType.Resolve().FindMethod("ToUniversalTime"));
-
+                
                 var variable = new VariableDefinition(returnType);
                 variables.Add(variable);
                 ins.Add(Instruction.Create(OpCodes.Stloc, variable));
@@ -211,7 +211,7 @@ public class ModuleWeaver
             {
                 AssignFalseToFirstFLag(ins);
 
-                If(ins,
+                If(ins, 
                     nc => nc.Add(Instruction.Create(OpCodes.Dup)),
                     nt =>
                     {
@@ -253,21 +253,21 @@ public class ModuleWeaver
                                             format = "{0}";
                                         }
 
-                                        t.Add(Instruction.Create(OpCodes.Ldstr, format));
+                                        t.Add(Instruction.Create(OpCodes.Ldstr, format));  
 
                                         t.Add(Instruction.Create(OpCodes.Ldc_I4, 1));
-                                        t.Add(Instruction.Create(OpCodes.Newarr, ModuleDefinition.TypeSystem.Object));
-                                        t.Add(Instruction.Create(OpCodes.Stloc, body.Variables[4]));
-                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4]));
+                                        t.Add(Instruction.Create(OpCodes.Newarr, ModuleDefinition.TypeSystem.Object)); 
+                                        t.Add(Instruction.Create(OpCodes.Stloc, body.Variables[4])); 
+                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4])); 
 
-                                        t.Add(Instruction.Create(OpCodes.Ldc_I4_0));
+                                        t.Add(Instruction.Create(OpCodes.Ldc_I4_0)); 
 
-                                        t.Add(Instruction.Create(OpCodes.Ldloc_2));
-                                        t.Add(Instruction.Create(OpCodes.Callvirt, current));
+                                        t.Add(Instruction.Create(OpCodes.Ldloc_2)); 
+                                        t.Add(Instruction.Create(OpCodes.Callvirt, current)); 
 
 
                                         t.Add(Instruction.Create(OpCodes.Stelem_Ref));
-                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4]));
+                                        t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4])); 
 
                                         t.Add(Instruction.Create(OpCodes.Call, formatMethod));
                                     },
@@ -277,13 +277,13 @@ public class ModuleWeaver
                             });
 
                         AppendString(ins, ListEnd);
-                        StringBuilderToString(ins);
+                        StringBuilderToString(ins);       
                     },
                     nf =>
                     {
                         ins.Add(Instruction.Create(OpCodes.Pop));
-                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null"));
-                    });
+                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null")); 
+                    });              
             }
             else
             {
@@ -297,7 +297,7 @@ public class ModuleWeaver
                     e =>
                     {
                         ins.Add(Instruction.Create(OpCodes.Pop));
-                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null"));
+                        ins.Add(Instruction.Create(OpCodes.Ldstr, "null"));   
                     });
             }
         }
@@ -316,7 +316,7 @@ public class ModuleWeaver
 
     void NewStringBuilder(Collection<Instruction> ins)
     {
-        var stringBuilderConstructor = ModuleDefinition.ImportReference(typeof(StringBuilder).GetConstructor(new Type[] { }));
+        var stringBuilderConstructor = ModuleDefinition.ImportReference(typeof (StringBuilder).GetConstructor(new Type[] {}));
         ins.Add(Instruction.Create(OpCodes.Newobj, stringBuilderConstructor));
         ins.Add(Instruction.Create(OpCodes.Stloc_1));
     }
@@ -336,7 +336,7 @@ public class ModuleWeaver
     void While(
         Collection<Instruction> ins,
         Action<Collection<Instruction>> condition,
-        Action<Collection<Instruction>> body)
+        Action<Collection<Instruction>> body )
     {
         var loopBegin = Instruction.Create(OpCodes.Nop);
         var loopEnd = Instruction.Create(OpCodes.Nop);
@@ -455,13 +455,13 @@ public class ModuleWeaver
             sb.Append('{');
             sb.Append(i + offset);
 
-            if (property.PropertyType.FullName == "System.DateTime")
+            if( property.PropertyType.FullName == "System.DateTime" )
             {
                 sb.Append(":O");
             }
             if (property.PropertyType.FullName == "System.TimeSpan")
             {
-                sb.Append(":c");
+                sb.Append( ":c" );
             }
 
             sb.Append("}");
@@ -489,14 +489,14 @@ public class ModuleWeaver
     static bool HaveToAddQuotes(TypeReference type)
     {
         var name = type.FullName;
-        if (name == "System.String" || name == "System.Char" || name == "System.DateTime" || name == "System.TimeSpan"
+        if(name == "System.String" || name == "System.Char" || name == "System.DateTime" || name == "System.TimeSpan"
             || name == "System.Guid")
         {
             return true;
         }
 
         var resolved = type.Resolve();
-        return resolved != null && resolved.IsEnum;
+        return  resolved != null && resolved.IsEnum;
     }
 
     void RemoveReference()

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -219,7 +219,7 @@ public class ModuleWeaver
 
                         NewStringBuilder(nt);
 
-                        AppendString(nt, "[");
+                        AppendString(nt, ListStart);
 
                         While(nt,
                             c =>
@@ -276,7 +276,7 @@ public class ModuleWeaver
                                 ins.Add(Instruction.Create(OpCodes.Pop));
                             });
 
-                        AppendString(ins, "]");
+                        AppendString(ins, ListEnd);
                         StringBuilderToString(ins);
                     },
                     nf =>
@@ -525,6 +525,10 @@ public class ModuleWeaver
     private string PropertyNameToValueSeparator => ReadStringValueFromConfig("PropertyNameToValueSeparator", ": ");
 
     private string PropertiesSeparator => ReadStringValueFromConfig("PropertiesSeparator", ", ");
+
+    private string ListStart => ReadStringValueFromConfig("ListStart", "[");
+
+    private string ListEnd => ReadStringValueFromConfig("ListEnd", "]");
 
     private bool WrapWithBrackets => ReadBoolValueFromConfig("WrapWithBrackets", true);
 

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -269,7 +269,7 @@ public class ModuleWeaver
                                         t.Add(Instruction.Create(OpCodes.Stelem_Ref));
                                         t.Add(Instruction.Create(OpCodes.Ldloc, body.Variables[4])); 
 
-                                        t.Add(Instruction.Create(OpCodes.Call, formatMethod));
+                                        t.Add(Instruction.Create(OpCodes.Call, formatMethod)); 
                                     },
                                     e => e.Add(Instruction.Create(OpCodes.Ldstr, "null")));
                                 ins.Add(Instruction.Create(OpCodes.Callvirt, appendString));

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -287,7 +287,7 @@ public class ModuleWeaver
             }
             else
             {
-                If(ins,
+                If(ins, 
                     c =>
                     {
                         ins.Add(Instruction.Create(OpCodes.Dup));
@@ -455,11 +455,11 @@ public class ModuleWeaver
             sb.Append('{');
             sb.Append(i + offset);
 
-            if( property.PropertyType.FullName == "System.DateTime" )
+            if (property.PropertyType.FullName == "System.DateTime")
             {
                 sb.Append(":O");
             }
-            if (property.PropertyType.FullName == "System.TimeSpan")
+            if( property.PropertyType.FullName == "System.TimeSpan" )
             {
                 sb.Append( ":c" );
             }

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -187,12 +187,12 @@ public class ModuleWeaver
         ins.Add(Instruction.Create(OpCodes.Ldarg_0));
         ins.Add(Instruction.Create(OpCodes.Call, get));
 
-        if (get.ReturnType.IsValueType)
+        if ( get.ReturnType.IsValueType)
         {
             var returnType = ModuleDefinition.ImportReference(property.GetMethod.ReturnType);
-            if ( returnType.FullName == "System.DateTime" )
+            if( returnType.FullName == "System.DateTime" )
             {
-                var convertToUtc = ModuleDefinition.ImportReference(returnType.Resolve().FindMethod("ToUniversalTime"));
+                var convertToUtc = ModuleDefinition.ImportReference(returnType.Resolve().FindMethod( "ToUniversalTime" ));
                 
                 var variable = new VariableDefinition(returnType);
                 variables.Add(variable);

--- a/Tests/AttributesConfiguration.cs
+++ b/Tests/AttributesConfiguration.cs
@@ -1,0 +1,9 @@
+public class AttributesConfiguration
+{
+    public string PropertyNameToValueSeparator { get; set; }
+    public string PropertiesSeparator { get; set; }
+    public bool? WrapWithBrackets { get; set; }
+    public bool? WriteTypeName { get; set; }
+    public string ListStart { get; set; }
+    public string ListEnd { get; set; }
+}

--- a/Tests/AttributesTests.cs
+++ b/Tests/AttributesTests.cs
@@ -9,11 +9,13 @@ public class AttributesTests
     private string PropertiesSeparator = "$@#@$";
     private bool WrapWithBrackets = false;
     private bool WriteTypeName = false;
+    private string ListStart = "---[[[";
+    private string ListEnd = "]]]---";
 
-    public Assembly PrepareAssembly(string name, string propertyNameToValueSeparator, string propertiesSeparator, bool? wrapWithBrackets, bool? writeTypeName)
+    public Assembly PrepareAssembly(string name, AttributesConfiguration configuration)
     {
-        var config = TestHelper.PrepareConfig(propertyNameToValueSeparator, propertiesSeparator, wrapWithBrackets, writeTypeName);
-        
+        var config = TestHelper.PrepareConfig(configuration);
+
         var testSetup = TestHelper.PrepareDll(name);
 
         var weavingTask = new ModuleWeaver
@@ -32,7 +34,7 @@ public class AttributesTests
     [Test]
     public void NormalClassTest_ShouldUseCustomPropertyNameToValueSeparator()
     {
-        var assembly = PrepareAssembly("test1", PropertyNameToValueSeparator, null, null, null);
+        var assembly = PrepareAssembly("test1", new AttributesConfiguration { PropertyNameToValueSeparator = PropertyNameToValueSeparator });
 
         var type = assembly.GetType("NormalClass");
         dynamic instance = Activator.CreateInstance(type);
@@ -44,14 +46,14 @@ public class AttributesTests
         var result = instance.ToString();
 
         Assert.AreEqual(
-            string.Format("{{T{0}\"NormalClass\", X{0}1, Y{0}\"2\", Z{0}4.5, V{0}\"C\"}}", PropertyNameToValueSeparator), 
+            string.Format("{{T{0}\"NormalClass\", X{0}1, Y{0}\"2\", Z{0}4.5, V{0}\"C\"}}", PropertyNameToValueSeparator),
             result);
     }
 
     [Test]
     public void NormalClassTest_ShouldUseCustomPropertiesSeparator()
     {
-        var assembly = PrepareAssembly("test2", null, PropertiesSeparator, null, null);
+        var assembly = PrepareAssembly("test2", new AttributesConfiguration { PropertiesSeparator = PropertiesSeparator });
 
         var type = assembly.GetType("NormalClass");
         dynamic instance = Activator.CreateInstance(type);
@@ -63,14 +65,14 @@ public class AttributesTests
         var result = instance.ToString();
 
         Assert.AreEqual(
-            string.Format("{{T: \"NormalClass\"{0}X: 1{0}Y: \"2\"{0}Z: 4.5{0}V: \"C\"}}", PropertiesSeparator), 
+            string.Format("{{T: \"NormalClass\"{0}X: 1{0}Y: \"2\"{0}Z: 4.5{0}V: \"C\"}}", PropertiesSeparator),
             result);
     }
 
     [Test]
     public void NormalClassTest_ShouldNotWrapInBrackets()
     {
-        var assembly = PrepareAssembly("test3", null, null, false, null);
+        var assembly = PrepareAssembly("test3", new AttributesConfiguration { WrapWithBrackets = WrapWithBrackets });
 
         var type = assembly.GetType("NormalClass");
         dynamic instance = Activator.CreateInstance(type);
@@ -82,14 +84,14 @@ public class AttributesTests
         var result = instance.ToString();
 
         Assert.AreEqual(
-            "T: \"NormalClass\", X: 1, Y: \"2\", Z: 4.5, V: \"C\"", 
+            "T: \"NormalClass\", X: 1, Y: \"2\", Z: 4.5, V: \"C\"",
             result);
     }
 
     [Test]
     public void NormalClassTest_ShouldNotWriteClassName()
     {
-        var assembly = PrepareAssembly("test4", null, null, null, false);
+        var assembly = PrepareAssembly("test4", new AttributesConfiguration { WriteTypeName = WriteTypeName });
 
         var type = assembly.GetType("NormalClass");
         dynamic instance = Activator.CreateInstance(type);
@@ -101,7 +103,41 @@ public class AttributesTests
         var result = instance.ToString();
 
         Assert.AreEqual(
-            "{X: 1, Y: \"2\", Z: 4.5, V: \"C\"}", 
+            "{X: 1, Y: \"2\", Z: 4.5, V: \"C\"}",
             result);
+    }
+
+    [Test]
+    public void NormalClassTest_ShouldStartListWithCustomSeparator()
+    {
+        var assembly = PrepareAssembly("test5", new AttributesConfiguration { ListStart = ListStart });
+
+        var type = assembly.GetType("IntCollection");
+        dynamic instance = Activator.CreateInstance(type);
+        instance.Collection = new[] { 1, 2, 3, 4, 5, 6 };
+        instance.Count = 2;
+
+        var result = instance.ToString();
+
+        var expected = $"{{T: \"IntCollection\", Count: 2, Collection: {ListStart}1, 2, 3, 4, 5, 6]}}";
+
+        Assert.AreEqual(expected, result);
+    }
+
+    [Test]
+    public void NormalClassTest_ShouldEndListWithCustomSeparator()
+    {
+        var assembly = PrepareAssembly("test6", new AttributesConfiguration { ListEnd = ListEnd });
+
+        var type = assembly.GetType("IntCollection");
+        dynamic instance = Activator.CreateInstance(type);
+        instance.Collection = new[] { 1, 2, 3, 4, 5, 6 };
+        instance.Count = 2;
+
+        var result = instance.ToString();
+
+        var expected = $"{{T: \"IntCollection\", Count: 2, Collection: [1, 2, 3, 4, 5, 6{ListEnd}}}";
+
+        Assert.AreEqual(expected, result);
     }
 }

--- a/Tests/AttributesTests.cs
+++ b/Tests/AttributesTests.cs
@@ -1,0 +1,107 @@
+﻿using NUnit.Framework;
+using System;
+using System.Reflection;
+
+[TestFixture]
+public class AttributesTests
+{
+    private string PropertyNameToValueSeparator = "$%^%$";
+    private string PropertiesSeparator = "$@#@$";
+    private bool WrapWithBrackets = false;
+    private bool WriteTypeName = false;
+
+    public Assembly PrepareAssembly(string name, string propertyNameToValueSeparator, string propertiesSeparator, bool? wrapWithBrackets, bool? writeTypeName)
+    {
+        var config = TestHelper.PrepareConfig(propertyNameToValueSeparator, propertiesSeparator, wrapWithBrackets, writeTypeName);
+        
+        var testSetup = TestHelper.PrepareDll(name);
+
+        var weavingTask = new ModuleWeaver
+        {
+            ModuleDefinition = testSetup.ModuleDefinition,
+            AssemblyResolver = testSetup.MockAssemblyResolver,
+            Config = config
+        };
+
+        weavingTask.Execute();
+        testSetup.ModuleDefinition.Write(testSetup.AfterAssemblyPath);
+
+        return Assembly.LoadFile(testSetup.AfterAssemblyPath);
+    }
+
+    [Test]
+    public void NormalClassTest_ShouldUseCustomPropertyNameToValueSeparator()
+    {
+        var assembly = PrepareAssembly("test1", PropertyNameToValueSeparator, null, null, null);
+
+        var type = assembly.GetType("NormalClass");
+        dynamic instance = Activator.CreateInstance(type);
+        instance.X = 1;
+        instance.Y = "2";
+        instance.Z = 4.5;
+        instance.V = 'C';
+
+        var result = instance.ToString();
+
+        Assert.AreEqual(
+            string.Format("{{T{0}\"NormalClass\", X{0}1, Y{0}\"2\", Z{0}4.5, V{0}\"C\"}}", PropertyNameToValueSeparator), 
+            result);
+    }
+
+    [Test]
+    public void NormalClassTest_ShouldUseCustomPropertiesSeparator()
+    {
+        var assembly = PrepareAssembly("test2", null, PropertiesSeparator, null, null);
+
+        var type = assembly.GetType("NormalClass");
+        dynamic instance = Activator.CreateInstance(type);
+        instance.X = 1;
+        instance.Y = "2";
+        instance.Z = 4.5;
+        instance.V = 'C';
+
+        var result = instance.ToString();
+
+        Assert.AreEqual(
+            string.Format("{{T: \"NormalClass\"{0}X: 1{0}Y: \"2\"{0}Z: 4.5{0}V: \"C\"}}", PropertiesSeparator), 
+            result);
+    }
+
+    [Test]
+    public void NormalClassTest_ShouldNotWrapInBrackets()
+    {
+        var assembly = PrepareAssembly("test3", null, null, false, null);
+
+        var type = assembly.GetType("NormalClass");
+        dynamic instance = Activator.CreateInstance(type);
+        instance.X = 1;
+        instance.Y = "2";
+        instance.Z = 4.5;
+        instance.V = 'C';
+
+        var result = instance.ToString();
+
+        Assert.AreEqual(
+            "T: \"NormalClass\", X: 1, Y: \"2\", Z: 4.5, V: \"C\"", 
+            result);
+    }
+
+    [Test]
+    public void NormalClassTest_ShouldNotWriteClassName()
+    {
+        var assembly = PrepareAssembly("test4", null, null, null, false);
+
+        var type = assembly.GetType("NormalClass");
+        dynamic instance = Activator.CreateInstance(type);
+        instance.X = 1;
+        instance.Y = "2";
+        instance.Z = 4.5;
+        instance.V = 'C';
+
+        var result = instance.ToString();
+
+        Assert.AreEqual(
+            "{X: 1, Y: \"2\", Z: 4.5, V: \"C\"}", 
+            result);
+    }
+}

--- a/Tests/TestHelper.cs
+++ b/Tests/TestHelper.cs
@@ -1,0 +1,79 @@
+using Mono.Cecil;
+using NUnit.Framework;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+
+public static class TestHelper
+{
+    public static TestSetupDefinition PrepareDll(string assemblyNameSuffix)
+    {
+
+        string beforeAssemblyPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, @"..\..\..\AssemblyToProcess\bin\Debug\AssemblyToProcess.dll"));
+#if (!DEBUG)
+
+        beforeAssemblyPath = beforeAssemblyPath.Replace("Debug", "Release");
+#endif
+
+        string afterAssemblyPath = beforeAssemblyPath.Replace(".dll", assemblyNameSuffix + ".dll");
+        File.Copy(beforeAssemblyPath, afterAssemblyPath, true);
+
+        var assemblyResolver = new MockAssemblyResolver
+        {
+            Directory = Path.GetDirectoryName(beforeAssemblyPath)
+        };
+        var moduleDefinition = ModuleDefinition.ReadModule(afterAssemblyPath, new ReaderParameters
+        {
+            AssemblyResolver = assemblyResolver
+        });
+
+        return new TestSetupDefinition
+        {
+            AfterAssemblyPath = afterAssemblyPath,
+            ModuleDefinition = moduleDefinition,
+            MockAssemblyResolver = assemblyResolver
+        };
+    }
+
+    public static XElement PrepareConfig(string propertyNameToValueSeparator, string propertiesSeparator, bool? wrapWithBrackets, bool? writeTypeName)
+    {
+        XElement config;
+
+        var configXml = new StringBuilder();
+        configXml.Append("<ToString ");
+        if (!string.IsNullOrEmpty(propertyNameToValueSeparator))
+        {
+            configXml.AppendFormat("PropertyNameToValueSeparator=\"{0}\" ", propertyNameToValueSeparator);
+        }
+        if (!string.IsNullOrEmpty(propertiesSeparator))
+        {
+            configXml.AppendFormat("PropertiesSeparator=\"{0}\" ", propertiesSeparator);
+        }
+        if (wrapWithBrackets.HasValue)
+        {
+            configXml.AppendFormat("WrapWithBrackets=\"{0}\" ", wrapWithBrackets);
+        }
+        if (writeTypeName.HasValue)
+        {
+            configXml.AppendFormat("WriteTypeName=\"{0}\" ", writeTypeName);
+        }
+        configXml.Append("/>");
+
+        using (var configStream = GenerateStreamFromString(configXml.ToString()))
+        {
+            config = XElement.Load(configStream);
+        }
+
+        return config;
+    }
+
+    private static Stream GenerateStreamFromString(string s)
+    {
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
+        writer.Write(s);
+        writer.Flush();
+        stream.Position = 0;
+        return stream;
+    }
+}

--- a/Tests/TestHelper.cs
+++ b/Tests/TestHelper.cs
@@ -35,27 +35,35 @@ public static class TestHelper
         };
     }
 
-    public static XElement PrepareConfig(string propertyNameToValueSeparator, string propertiesSeparator, bool? wrapWithBrackets, bool? writeTypeName)
+    public static XElement PrepareConfig(AttributesConfiguration configuration)
     {
         XElement config;
 
         var configXml = new StringBuilder();
         configXml.Append("<ToString ");
-        if (!string.IsNullOrEmpty(propertyNameToValueSeparator))
+        if (!string.IsNullOrEmpty(configuration.PropertyNameToValueSeparator))
         {
-            configXml.AppendFormat("PropertyNameToValueSeparator=\"{0}\" ", propertyNameToValueSeparator);
+            configXml.AppendFormat("PropertyNameToValueSeparator=\"{0}\" ", configuration.PropertyNameToValueSeparator);
         }
-        if (!string.IsNullOrEmpty(propertiesSeparator))
+        if (!string.IsNullOrEmpty(configuration.PropertiesSeparator))
         {
-            configXml.AppendFormat("PropertiesSeparator=\"{0}\" ", propertiesSeparator);
+            configXml.AppendFormat("PropertiesSeparator=\"{0}\" ", configuration.PropertiesSeparator);
         }
-        if (wrapWithBrackets.HasValue)
+        if (configuration.WrapWithBrackets.HasValue)
         {
-            configXml.AppendFormat("WrapWithBrackets=\"{0}\" ", wrapWithBrackets);
+            configXml.AppendFormat("WrapWithBrackets=\"{0}\" ", configuration.WrapWithBrackets);
         }
-        if (writeTypeName.HasValue)
+        if (configuration.WriteTypeName.HasValue)
         {
-            configXml.AppendFormat("WriteTypeName=\"{0}\" ", writeTypeName);
+            configXml.AppendFormat("WriteTypeName=\"{0}\" ", configuration.WriteTypeName);
+        }
+        if (!string.IsNullOrEmpty(configuration.ListStart))
+        {
+            configXml.AppendFormat("ListStart=\"{0}\" ", configuration.ListStart);
+        }
+        if (!string.IsNullOrEmpty(configuration.ListEnd))
+        {
+            configXml.AppendFormat("ListEnd=\"{0}\" ", configuration.ListEnd);
         }
         configXml.Append("/>");
 

--- a/Tests/TestSetupDefinition.cs
+++ b/Tests/TestSetupDefinition.cs
@@ -1,0 +1,10 @@
+﻿using Mono.Cecil;
+
+public class TestSetupDefinition
+{
+    public string AfterAssemblyPath { get; set; }
+
+    public ModuleDefinition ModuleDefinition { get; set; }
+
+    public MockAssemblyResolver MockAssemblyResolver { get; set; }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -64,6 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AttributesConfiguration.cs" />
     <Compile Include="AttributesTests.cs" />
     <Compile Include="MockAssemblyResolver.cs" />
     <Compile Include="IntegrationTests.cs" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -64,8 +64,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AttributesTests.cs" />
     <Compile Include="MockAssemblyResolver.cs" />
     <Compile Include="IntegrationTests.cs" />
+    <Compile Include="TestHelper.cs" />
+    <Compile Include="TestSetupDefinition.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyToReference\AssemblyToReference.csproj">


### PR DESCRIPTION
I've added 4 parameters to configure output:
PropertyNameToValueSeparator - defines the separator used between property name and property value
PropertiesSeparator - defines separator used between properties (and between class name and first property)
WrapWithBrackets - defines if output should be wrapped with curly brackets
WriteTypeName - defines if T: <ClassName> should be in output.

All attributes have fall-back strategy to normal behavior - so if no parameters are provided output is exactly the same as it was before this change.

Usage:
`<ToString PropertyNameToValueSeparator="->" PropertiesSeparator=" , " WrapWithBrackets="false" WriteTypeName="false" />`

I made those changes because this lib is doing great job but I needed the ToString output less human-readable, more easy-to-process later.
